### PR TITLE
Add pen.register-trainee-teachers.education.gov.uk to cdn.config.yml

### DIFF
--- a/scripts/cloudfoundry/bat-cdn/cdn-config.yml
+++ b/scripts/cloudfoundry/bat-cdn/cdn-config.yml
@@ -9,6 +9,7 @@ qa:
     - qa.register-trainee-teachers.education.gov.uk
     - qa.api.publish-teacher-training-courses.service.gov.uk
     - qa.publish-teacher-training-courses.service.gov.uk
+    - pen.register-trainee-teachers.education.gov.uk
 staging:
   headers: *headers
   domain:


### PR DESCRIPTION
Update CDN-config.yml with Pen-test url pen.register-trainee-teachers.education.gov.uk. This is to ensure the list is up to date.