### PR TITLE
Add audit.register*.education.gov.uk to cdn_config.yml

### DIFF
--- a/scripts/cloudfoundry/bat-cdn/cdn-config.yml
+++ b/scripts/cloudfoundry/bat-cdn/cdn-config.yml
@@ -8,6 +8,7 @@ qa:
     - qa.register-trainee-teachers.education.gov.uk
     - qa.api.publish-teacher-training-courses.service.gov.uk
     - qa.publish-teacher-training-courses.service.gov.uk
+    - audit.register-trainee-teachers.education.gov.uk
 staging:
   headers: *headers
   domain:


### PR DESCRIPTION
Add audit.register*.education.gov.uk to cdn_config.yml to keep the list of customdomain uptodate.