### PR TITLE
Do not run terraform plan

### DIFF
--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -24,8 +24,7 @@ jobs:
       - name: Terraform init, plan & apply
         run: |
           terraform init -backend-config workspace-variables/backend_${TF_VAR_monitoring_env}.tfvars
-          terraform plan -var-file workspace-variables/${TF_VAR_monitoring_env}.tfvars -out monitoring_tfplan
-          terraform apply "monitoring_tfplan"
+          terraform apply -var-file workspace-variables/${TF_VAR_monitoring_env}.tfvars -auto-approve
         working-directory: monitoring
         env:
           ARM_ACCESS_KEY: ${{ secrets[format('TERRAFORM_STATE_ACCESS_KEY_{0}', github.event.inputs.environment)] }}


### PR DESCRIPTION
## What
Terraform plan might expose secrets in some cases and since the repo is public it would show in the actions log
We simply remove the plan step. It can always be run on command line for troubleshooting

## Review
Successful run: https://github.com/DFE-Digital/bat-infrastructure/runs/2409467957?check_suite_focus=true

