### PR TITLE
Postgres as backing datastore for SQLPad

### DIFF
--- a/sqlpad/data.tf
+++ b/sqlpad/data.tf
@@ -10,3 +10,7 @@ data "cloudfoundry_space" "space" {
 data "cloudfoundry_domain" "london_cloudapps_digital" {
   name = "london.cloudapps.digital"
 }
+
+data "cloudfoundry_service" "postgres" {
+  name = "postgres"
+}

--- a/sqlpad/resources.tf
+++ b/sqlpad/resources.tf
@@ -10,10 +10,24 @@ resource "cloudfoundry_app" "sqlpad" {
   routes {
     route = cloudfoundry_route.web_app_cloudapps_digital_route.id
   }
+  service_binding {
+    service_instance = cloudfoundry_service_instance.postgres.id
+  }
 }
 
 resource "cloudfoundry_route" "web_app_cloudapps_digital_route" {
   domain   = data.cloudfoundry_domain.london_cloudapps_digital.id
   space    = data.cloudfoundry_space.space.id
   hostname = local.app_name
+}
+
+resource "cloudfoundry_service_instance" "postgres" {
+  name         = local.postgres_name
+  space        = data.cloudfoundry_space.space.id
+  service_plan = data.cloudfoundry_service.postgres.service_plans["tiny-unencrypted-12"]
+}
+
+resource "cloudfoundry_service_key" "postgres_service_key" {
+  name             = "${local.postgres_name}-key"
+  service_instance = cloudfoundry_service_instance.postgres.id
 }


### PR DESCRIPTION
To persists users and other config across instances/restarts.

This has been deployed.