### PR TITLE
CDN endpoints added for School experience.

### DIFF
--- a/scripts/cloudfoundry/cdn/cdn-config.yml
+++ b/scripts/cloudfoundry/cdn/cdn-config.yml
@@ -65,7 +65,6 @@ git-prod:
     - beta-adviser-getintoteaching.education.gov.uk
     - getintoteaching.education.gov.uk
     - beta-getintoteaching.education.gov.uk
-    - schoolexperience.education.gov.uk
 apply-qa:
   service: apply-cdn-qa
   headers: *apply-headers

--- a/scripts/cloudfoundry/cdn/cdn-config.yml
+++ b/scripts/cloudfoundry/cdn/cdn-config.yml
@@ -24,6 +24,11 @@ bat-staging:
     - staging.register-trainee-teachers.education.gov.uk
     - staging.api.publish-teacher-training-courses.service.gov.uk
     - staging.publish-teacher-training-courses.service.gov.uk
+se-staging:
+  service: schoolexperience-cdn-test
+  headers: *headers
+  domain:
+    - schoolexperience-staging.education.gov.uk
 git-staging:
   service: get-into-teaching-cdn-test
   headers: *headers
@@ -43,6 +48,11 @@ bat-prod:
     - sandbox.publish-teacher-training-courses.service.gov.uk
     - sandbox.register-trainee-teachers.education.gov.uk
     - www.publish-teacher-training-courses.service.gov.uk
+se-prod:
+  service: schoolexperience-cdn-prod
+  headers: *headers
+  domain:
+    - schoolexperience.education.gov.uk
 git-prod:
   service: get-into-teaching-cdn-prod
   headers: *headers

--- a/scripts/cloudfoundry/cdn/cdn-config.yml
+++ b/scripts/cloudfoundry/cdn/cdn-config.yml
@@ -30,6 +30,7 @@ git-staging:
   domain:
     - staging-adviser-getintoteaching.education.gov.uk
     - staging-getintoteaching.education.gov.uk
+    - staging-schoolexperience.education.gov.uk
 bat-prod:
   service: bat-cdn-prod
   headers: *headers

--- a/scripts/cloudfoundry/cdn/cdn-config.yml
+++ b/scripts/cloudfoundry/cdn/cdn-config.yml
@@ -40,7 +40,6 @@ git-staging:
     - staging-adviser-getintoteaching.education.gov.uk
     - staging-getintoteaching.education.gov.uk
     - staging-schoolexperience.education.gov.uk
-    - schoolexperience-staging.education.gov.uk
 bat-prod:
   service: bat-cdn-prod
   headers: *all-headers


### PR DESCRIPTION
Two end points added, one for staging and one for production these are to migrate the current environments settings away from the Azure version to PaaS version.

## Review note:
The existing School Experience endpoint is currently pointing to PaaS and is the alternative staging endpoint. It should not be removed just yet.
