### PR TITLE
Get Into Teaching Asset Cache

### DIFF
--- a/scripts/cloudfoundry/cdn/cdn-config.yml
+++ b/scripts/cloudfoundry/cdn/cdn-config.yml
@@ -38,6 +38,11 @@ git-staging:
     - staging-adviser-getintoteaching.education.gov.uk
     - staging-getintoteaching.education.gov.uk
     - staging-schoolexperience.education.gov.uk
+git-assets-staging:
+  service: get-into-teaching-cdn-test-assets
+  cookies: false
+  domain:
+    - assets.staging-getintoteaching.education.gov.uk
 bat-prod:
   service: bat-cdn-prod
   headers: *all-headers


### PR DESCRIPTION
Have a seperated Cloud Front for Assets, so we can have independent cacheing rules, allowing assets to avoid problems with authorization and cookie headers