### PR TITLE
School Experience requires all headers

### DIFF
--- a/scripts/cloudfoundry/cdn/cdn-config.yml
+++ b/scripts/cloudfoundry/cdn/cdn-config.yml
@@ -34,7 +34,7 @@ bat-staging:
     
 se-staging:
   service: schoolexperience-cdn-test
-  headers: *headers
+  headers: *all-headers
   domain:
     - schoolexperience-staging.education.gov.uk
 
@@ -59,7 +59,7 @@ bat-prod:
     - api.publish-teacher-training-courses.service.gov.uk
 se-prod:
   service: schoolexperience-cdn-prod
-  headers: *headers
+  headers: *all-headers
   domain:
     - schoolexperience.education.gov.uk
 git-prod:


### PR DESCRIPTION
## Cookie page blacklisted
The cookie page on SE is blacklisted because the referer header is not being passed through cloud front.

## Fix
For SE pass through all headers