### PR TITLE
Alter Response Times alert to use histogram bucket

### DIFF
--- a/monitoring/config/alert.rules.tmpl
+++ b/monitoring/config/alert.rules.tmpl
@@ -1,97 +1,97 @@
 groups:
 - name: High CPU
   rules:
-%{ for app in apps ~}
-  - alert: High-CPU-${app}
-    expr: avg by ( app ) (cpu{app=~"${app}"}) > 50
+%{ for app_name, app_config in apps ~}
+  - alert: High-CPU-${app_name}
+    expr: avg by ( app ) (cpu{app=~"${app_name}"}) > 50
     for: 5m
     annotations:
-      summary:     ${app} High CPU Alert
-      dashboard:   ${grafana_dashboard_url}&var-Applications=${app}
+      summary:     ${app_name} High CPU Alert
+      dashboard:   ${grafana_dashboard_url}&var-Applications=${app_name}
       description: "CPU usage has increased in the last 5 minutes (current value: {{ $value }}%)"
     labels:
       environment: production
       severity:    high
-      app:         ${app}
+      app:         ${app_name}
 %{ endfor ~}
 
 - name: Memory Utilisation
   rules:
-%{ for app in apps ~}
-  - alert: High-Memory-Utilisation-${app}
-    expr: avg by ( app ) (memory_utilization{app=~"${app}"}) > 60
+%{ for app_name, app_config in apps ~}
+  - alert: High-Memory-Utilisation-${app_name}
+    expr: avg by ( app ) (memory_utilization{app=~"${app_name}"}) > 60
     for: 5m
     annotations:
-      summary:     ${app} high memory utilization
-      dashboard:   ${grafana_dashboard_url}&var-Applications=${app}
+      summary:     ${app_name} high memory utilization
+      dashboard:   ${grafana_dashboard_url}&var-Applications=${app_name}
       description: "Memory utilization has increased in the last 5 minutes (current value: {{ $value }}%)"
     labels:
       severity:    high
-      app:         ${app}
+      app:         ${app_name}
       environment: production
 %{ endfor ~}
 
 - name: Disk Utilisation
   rules:
-%{ for app in apps ~}
-  - alert: High-Disk-Utilisation-${app}
-    expr: avg by ( app ) ( disk_utilization{ app=~"${app}" }) > 60
+%{ for app_name, app_config in apps ~}
+  - alert: High-Disk-Utilisation-${app_name}
+    expr: avg by ( app ) ( disk_utilization{ app=~"${app_name}" }) > 60
     for: 5m
     annotations:
-      summary:     ${app} high disk utilization
-      dashboard:   ${grafana_dashboard_url}&var-Applications=${app}
+      summary:     ${app_name} high disk utilization
+      dashboard:   ${grafana_dashboard_url}&var-Applications=${app_name}
       description: "Disk utilization has increased in the last 5 minutes (current value: {{ $value }})%"
     labels:
       severity:    high
-      app:         ${app}
+      app:         ${app_name}
       environment: production
 %{ endfor ~}
 
 - name: App Crashes
   rules:
-%{ for app in apps ~}
-  - alert: App-Crash-${app}
-    expr: rate(crash{app=~"${app}"}[1m])*60 > 1
+%{ for app_name, app_config in apps ~}
+  - alert: App-Crash-${app_name}
+    expr: rate(crash{app=~"${app_name}"}[1m])*60 > 1
     for: 5m
     annotations:
-      summary:     At least one instance of ${app} has crashed in the last 5 mins
-      dashboard:   ${grafana_dashboard_url}&var-Applications=${app}
-      description: At least one instance of ${app} has crashed in the last 5 mins
+      summary:     At least one instance of ${app_name} has crashed in the last 5 mins
+      dashboard:   ${grafana_dashboard_url}&var-Applications=${app_name}
+      description: At least one instance of ${app_name} has crashed in the last 5 mins
     labels:
       severity:    high
-      app:         ${app}
+      app:         ${app_name}
       environment: production
 %{ endfor ~}
 
 - name: Elevated Request Failures
   rules:
-%{ for app in apps ~}
-  - alert: Request-Failures-${app}
-    expr:  sum(rate(requests{app="${app}", status_range=~"0xx|4xx|5xx"}[5m]))*60 > 25
+%{ for app_name, app_config in apps ~}
+  - alert: Request-Failures-${app_name}
+    expr:  sum(rate(requests{app="${app_name}", status_range=~"0xx|4xx|5xx"}[5m]))*60 > 25
     for: 5m
     annotations:
       summary:     Failed requests count
-      dashboard:   ${grafana_dashboard_url}&var-Applications=${app}
-      description: "Number({{ $value }}) of non success status codes too high in the last 5 mins for ${app}"
+      dashboard:   ${grafana_dashboard_url}&var-Applications=${app_name}
+      description: "Number({{ $value }}) of non success status codes too high in the last 5 mins for ${app_name}"
     labels:
       severity:    high
-      app:         ${app}
+      app:         ${app_name}
       environment: production
 %{ endfor ~}
 
 - name: Average Response Time
   rules:
-%{ for app in apps ~}
-  - alert: Respose-Times-${app}
-    expr:  avg by (app) (rate(response_time_sum{app="${app}"}[5m])) > 2
+%{ for app_name, app_config in apps ~}
+  - alert: Response-Times-${app_name}
+    expr:  histogram_quantile(0.95, sum(rate(response_time_bucket{app="${app_name}", status_range="2xx"}[5m])) by (le)) > %{ if app_config.response_threshold == null }1%{ else }${app_config.response_threshold}%{ endif }
     for: 5m
     annotations:
-      summary:     Increased Response Times
-      dashboard:   ${grafana_dashboard_url}&var-Applications=${app}
-      description: "Average response time has increased in the last 5 mins and is now {{ $value }} seconds"
+      summary:     Slow running requests
+      dashboard:   ${grafana_dashboard_url}&var-Applications=${app_name}
+      description: "Requests in the 95 percentile taking longer than 3 seconds (current value: {{ humanize $value}}s )"
     labels:
       severity:    high
-      app:         ${app}
+      app:         ${app_name}
       environment: production
 %{ endfor ~}
 

--- a/monitoring/terraform.tf
+++ b/monitoring/terraform.tf
@@ -12,6 +12,7 @@ terraform {
   }
   backend "azurerm" {
   }
+  experiments = [module_variable_optional_attrs]
 }
 
 provider "cloudfoundry" {

--- a/monitoring/variables.tf
+++ b/monitoring/variables.tf
@@ -5,7 +5,13 @@ variable "monitoring_instance_name" {}
 
 variable "influxdb_service_plan" {}
 
-variable "alertmanager_app_names" {}
+variable "alertmanager_app_config" {
+  type = map(
+    object({
+      response_threshold = optional(number)
+    })
+  )
+}
 
 variable "postgres_services" {}
 variable "redis_services" {}
@@ -27,7 +33,7 @@ locals {
   alert_rules_variables = {
     grafana_dashboard_url     = "https://grafana-bat.london.cloudapps.digital/d/eF19g4RZx/cf-apps?orgId=1&refresh=10s&var-SpaceName=${var.monitoring_space_name}"
     redis_dashboard_url       = "https://grafana-bat.london.cloudapps.digital/d/_XaXFGTMz/redis?orgId=1&refresh=30s"
-    apps                      = var.alertmanager_app_names
+    apps                      = var.alertmanager_app_config
     alertable_redis_instances = [for r in var.alertable_redis_services : split("/", r)[1]]
   }
   alert_rules = templatefile("./config/alert.rules.tmpl", local.alert_rules_variables)

--- a/monitoring/workspace-variables/prod.tfvars.json
+++ b/monitoring/workspace-variables/prod.tfvars.json
@@ -5,18 +5,22 @@
   "monitoring_space_name": "bat-prod",
   "monitoring_instance_name": "bat",
   "influxdb_service_plan": "medium-1_x",
-  "alertmanager_app_names": [
-    "find-prod",
-    "find-staging",
-    "publish-teacher-training-prod",
-    "publish-teacher-training-staging",
-    "teacher-training-api-prod",
-    "teacher-training-api-staging",
-    "register-production",
-    "register-staging",
-    "apply-staging",
-    "apply-prod"
-  ],
+  "alertmanager_app_config": {
+    "find-prod": {},
+    "find-staging": {},
+    "publish-teacher-training-prod": {},
+    "publish-teacher-training-staging": {},
+    "teacher-training-api-prod": {
+      "response_threshold": 3
+    },
+    "teacher-training-api-staging": {
+      "response_threshold": 3
+    },
+    "register-production": {},
+    "register-staging": {},
+    "apply-staging": {},
+    "apply-prod": {}
+  },
   "postgres_services": [
     "bat-staging/apply-postgres-staging",
     "bat-staging/register-postgres-staging",

--- a/monitoring/workspace-variables/qa.tfvars.json
+++ b/monitoring/workspace-variables/qa.tfvars.json
@@ -5,13 +5,15 @@
   "monitoring_space_name": "bat-qa",
   "monitoring_instance_name": "bat-qa",
   "influxdb_service_plan": "tiny-1_x",
-  "alertmanager_app_names": [
-    "find-qa",
-    "publish-teacher-training-qa",
-    "teacher-training-api-qa",
-    "register-qa",
-    "apply-qa"
-  ],
+  "alertmanager_app_config": {
+    "find-qa": {},
+    "publish-teacher-training-qa": {},
+    "teacher-training-api-qa": {
+      "response_threshold": 3
+    },
+    "register-qa": {},
+    "apply-qa": {}
+  },
   "postgres_services": [
     "bat-qa/apply-postgres-qa",
     "bat-qa/register-postgres-qa",


### PR DESCRIPTION


## Context

The current response times alert is triggered by changes to the average response time, this can miss an increase in slow running requests if that is masked by high volumes of quick requests.  The histogram bucket looks at slowest performance for 95% of requests so provides a wider view whilst still excluding outliers.

## Changes proposed in this pull request

Change alert expressions to use histogram_quantile of response_time_bucket

## Guidance to review

Check alert filters and thresholds are appropriate

## Link to Trello card

https://trello.com/c/SfDpEYbL

## Things to check

- [x] Deploy to QA successfully
