### PR TITLE
Fix response time alerts

### DIFF
--- a/monitoring/config/alert.rules.tmpl
+++ b/monitoring/config/alert.rules.tmpl
@@ -88,7 +88,7 @@ groups:
     annotations:
       summary:     Slow running requests
       dashboard:   ${grafana_dashboard_url}&var-Applications=${app_name}
-      description: "Requests in the 95 percentile taking longer than 3 seconds (current value: {{ humanize $value}}s )"
+      description: "Requests in the 95 percentile taking longer than %{ if app_config.response_threshold == null }1%{ else }${app_config.response_threshold}%{ endif } seconds (current value: {{ humanize $value}}s )"
     labels:
       severity:    high
       app:         ${app_name}

--- a/monitoring/workspace-variables/prod.tfvars.json
+++ b/monitoring/workspace-variables/prod.tfvars.json
@@ -8,8 +8,12 @@
   "alertmanager_app_config": {
     "find-prod": {},
     "find-staging": {},
-    "publish-teacher-training-prod": {},
-    "publish-teacher-training-staging": {},
+    "publish-teacher-training-prod": {
+      "response_threshold": 2.5
+    },
+    "publish-teacher-training-staging": {
+      "response_threshold": 2.5
+    },
     "teacher-training-api-prod": {
       "response_threshold": 3
     },

--- a/monitoring/workspace-variables/qa.tfvars.json
+++ b/monitoring/workspace-variables/qa.tfvars.json
@@ -7,7 +7,9 @@
   "influxdb_service_plan": "tiny-1_x",
   "alertmanager_app_config": {
     "find-qa": {},
-    "publish-teacher-training-qa": {},
+    "publish-teacher-training-qa": {
+      "response_threshold": 2.5
+    },
     "teacher-training-api-qa": {
       "response_threshold": 3
     },


### PR DESCRIPTION
## Context

The alert description has a hardcoded value for the response time threshold but the expression accepts a configurable value.

The response_time threshold for publish-teacher-training doesn't reflect current app performance.

## Changes proposed in this pull request

- Response time alert description displays threshold from configuration
- Response time threshold increased for publish-teacher-training

## Guidance to review
- Check correct threshold is displayed in Prometheus alerts
- Check threshold is appropriate

## Link to Trello card
https://trello.com/c/SfDpEYbL

## Things to check
 - [x] Deploy to QA successfully