### PR TITLE
[436] Enable Prometheus-yearly

### DIFF
--- a/monitoring/resources.tf
+++ b/monitoring/resources.tf
@@ -25,4 +25,6 @@ module "prometheus_all" {
 
   redis_services    = local.redis_services
   postgres_services = var.postgres_services
+
+  enable_prometheus_yearly = true
 }


### PR DESCRIPTION
## What
Allow reading metrics stored for 1 year, such as the billing data. The retention policy and continuous query have already been created in influxdb QA and prod.

## How to review
Deploy to bat-qa and check the billing dashboard