### PR TITLE
Add DTTP portal domains to PaaS for register

### DIFF
--- a/scripts/cloudfoundry/cdn/cdn-config.yml
+++ b/scripts/cloudfoundry/cdn/cdn-config.yml
@@ -33,6 +33,7 @@ bat-staging:
     - pen.publish-teacher-training-courses.service.gov.uk
     - staging.register-trainee-teachers.education.gov.uk
     - staging2.publish-teacher-training-courses.service.gov.uk
+    - traineeteacherportal-pp.education.gov.uk
 
 se-staging:
   service: schoolexperience-cdn-test
@@ -66,6 +67,7 @@ bat-prod:
     - api.publish-teacher-training-courses.service.gov.uk
     - sandbox2.publish-teacher-training-courses.service.gov.uk
     - www2.publish-teacher-training-courses.service.gov.uk
+    - traineeteacherportal.education.gov.uk
 git-assets-production:
   service: get-into-teaching-cdn-prod-assets
   cookies: false


### PR DESCRIPTION

Adding DTTP portal domains to PaaS for register
-traineeteacherportal.education.gov.uk (bat-prod)
-traineeteacherportal-pp.education.gov.uk (bat-staging)

This is required for DTTP portal redirection
https://trello.com/c/272NMS5W/3820-setup-dttp-portal-domains-on-govuk-paas 