### PR TITLE
Add QA DTTP portal to bat-qa CDN

### DIFF
--- a/scripts/cloudfoundry/cdn/cdn-config.yml
+++ b/scripts/cloudfoundry/cdn/cdn-config.yml
@@ -21,6 +21,7 @@ bat-qa:
     - qa.publish-teacher-training-courses.service.gov.uk
     - audit.register-trainee-teachers.education.gov.uk
     - qa2.publish-teacher-training-courses.service.gov.uk
+    - traineeteacherportal-dv.education.gov.uk
 bat-staging:
   service: bat-cdn-staging
   headers: *all-headers


### PR DESCRIPTION
Adding DTTP portal domains to PaaS for register
-traineeteacherportal-dv.education.gov.uk (bat-qa)

This is required for DTTP portal redirection
https://trello.com/c/272NMS5W/3820-setup-dttp-portal-domains-on-govuk-paas