### PR TITLE
Add find-a-lost-trn domains

### DIFF
--- a/scripts/cloudfoundry/cdn/cdn-config.yml
+++ b/scripts/cloudfoundry/cdn/cdn-config.yml
@@ -142,3 +142,23 @@ tra-test:
   headers: *all-headers
   domain:
     - test-teacher-qualifications-api.education.gov.uk
+tra-falt-production:
+  service: find-a-lost-trn-cdn-production
+  headers: *all-headers
+  domain:
+    - find-a-lost-trn.education.gov.uk
+tra-falt-preprod:
+  service: find-a-lost-trn-cdn-preprod
+  headers: *all-headers
+  domain:
+    - preprod-find-a-lost-trn.education.gov.uk
+tra-falt-test:
+  service: find-a-lost-trn-cdn-test
+  headers: *all-headers
+  domain:
+    - test-find-a-lost-trn.education.gov.uk
+tra-falt-dev:
+  service: find-a-lost-trn-cdn-dev
+  headers: *all-headers
+  domain:
+    - dev-find-a-lost-trn.education.gov.uk


### PR DESCRIPTION
### Context

Custom domain on education.gov.uk needs to be added to all environment
of find-a-lost-trn. This commit adds records of PaaS CDN service instances
created.

### Trello card
https://trello.com/c/mvAzkPIB