### PR TITLE
Add Postgres alerting

### DIFF
--- a/monitoring/config/alert.rules.tmpl
+++ b/monitoring/config/alert.rules.tmpl
@@ -110,3 +110,51 @@ groups:
       app:         ${redis_instance}
       environment: production
 %{ endfor ~}
+
+- name: Postgres Memory Available
+  rules:
+%{ for postgres_instance in alertable_postgres_instances ~}
+  - alert: Postgres memory available low (instance - ${postgres_instance})
+    expr: freeable_memory_bytes{service=~"${postgres_instance}"} < (512 * 1024 * 1024)
+    for: 5m
+    annotations:
+      summary:     ${postgres_instance} low memory available
+      dashboard:   ${postgres_dashboard_url}&var-Services=${postgres_instance}
+      description: "Postgres Memory available is less than 512M (current value: {{ $value }})"
+    labels:
+      severity:    high
+      app:         ${postgres_instance}
+      environment: production
+%{ endfor ~}
+
+- name: Postgres CPU Utilisation
+  rules:
+%{ for postgres_instance in alertable_postgres_instances ~}
+  - alert: Postgres CPU Utilisation high (instance - ${postgres_instance})
+    expr: cpu_percent{service=~"${postgres_instance}"} > 60
+    for: 5m
+    annotations:
+      summary:     ${postgres_instance} high CPU Utilisation
+      dashboard:   ${postgres_dashboard_url}&var-Services=${postgres_instance}
+      description: "Postgres CPU Utilisation is above 60% (current value: {{ $value }})"
+    labels:
+      severity:    high
+      app:         ${postgres_instance}
+      environment: production
+%{ endfor ~}
+
+- name: Postgres Storage Utilisation
+  rules:
+%{ for postgres_instance in alertable_postgres_instances ~}
+  - alert: Postgres Storage available low (instance - ${postgres_instance})
+    expr: free_storage_space_bytes{service=~"${postgres_instance}"} < (1024 * 1024 * 1024)
+    for: 5m
+    annotations:
+      summary:     ${postgres_instance} low storage available
+      dashboard:   ${postgres_dashboard_url}&var-Services=${postgres_instance}
+      description: "Postgres Storage available is less than 1G (current value: {{ $value }})"
+    labels:
+      severity:    high
+      app:         ${postgres_instance}
+      environment: production
+%{ endfor ~}

--- a/monitoring/resources.tf
+++ b/monitoring/resources.tf
@@ -24,7 +24,7 @@ module "prometheus_all" {
   influxdb_service_plan = var.influxdb_service_plan
 
   redis_services    = local.redis_services
-  postgres_services = var.postgres_services
+  postgres_services = local.postgres_services
 
   enable_prometheus_yearly = true
 }

--- a/monitoring/variables.tf
+++ b/monitoring/variables.tf
@@ -16,6 +16,7 @@ variable "alertmanager_app_config" {
 variable "postgres_services" {}
 variable "redis_services" {}
 variable "alertable_redis_services" {}
+variable "alertable_postgres_services" {}
 
 variable "internal_apps" { default = [] }
 
@@ -33,10 +34,14 @@ locals {
   alert_rules_variables = {
     grafana_dashboard_url     = "https://grafana-bat.london.cloudapps.digital/d/eF19g4RZx/cf-apps?orgId=1&refresh=10s&var-SpaceName=${var.monitoring_space_name}"
     redis_dashboard_url       = "https://grafana-bat.london.cloudapps.digital/d/_XaXFGTMz/redis?orgId=1&refresh=30s"
+    postgres_dashboard_url    = "https://grafana-bat.london.cloudapps.digital/d/a2FR6FUMz/cf-databases?orgId=1&refresh=1m&var-SpaceName=${var.monitoring_space_name}"
     apps                      = var.alertmanager_app_config
     alertable_redis_instances = [for r in var.alertable_redis_services : split("/", r)[1]]
+    alertable_postgres_instances = [for r in var.alertable_postgres_services : split("/", r)[1]]
   }
   alert_rules = templatefile("./config/alert.rules.tmpl", local.alert_rules_variables)
 
   redis_services = concat(var.redis_services, var.alertable_redis_services)
+  postgres_services = concat(var.postgres_services, var.alertable_postgres_services)
+  
 }

--- a/monitoring/workspace-variables/prod.tfvars.json
+++ b/monitoring/workspace-variables/prod.tfvars.json
@@ -29,12 +29,14 @@
     "bat-staging/apply-postgres-staging",
     "bat-staging/register-postgres-staging",
     "bat-staging/teacher-training-api-postgres-staging",
-    "bat-prod/apply-postgres-prod",
     "bat-prod/apply-postgres-sandbox",
     "bat-prod/register-postgres-production",
     "bat-prod/register-postgres-sandbox",
     "bat-prod/teacher-training-api-postgres-prod",
     "bat-prod/teacher-training-api-postgres-sandbox"
+  ],
+  "alertable_postgres_services": [
+    "bat-prod/apply-postgres-prod"
   ],
   "redis_services": [
     "bat-staging/register-redis-cache-staging",

--- a/monitoring/workspace-variables/qa.tfvars.json
+++ b/monitoring/workspace-variables/qa.tfvars.json
@@ -17,9 +17,11 @@
     "apply-qa": {}
   },
   "postgres_services": [
+  ],
+  "alertable_postgres_services": [
+    "bat-qa/teacher-training-api-postgres-qa",
     "bat-qa/apply-postgres-qa",
-    "bat-qa/register-postgres-qa",
-    "bat-qa/teacher-training-api-postgres-qa"
+    "bat-qa/register-postgres-qa"
   ],
   "redis_services": [
     "bat-qa/apply-cache-redis-qa",


### PR DESCRIPTION
Adding Postgres alerting for memory, cpu and storage space.

Service is added to monitoring by moving it from variable postgres_services to alertable_postgres_services
(vice versa to remove from monitoring) 

Currently set to alert if
-Memory avail < 512MB
-Cpu usage > 60%
-Storage space avail < 1GB

https://trello.com/c/D42mz0JW/419-alerting-on-postgres-memory-cpu-limit

Config changes tested via 'make qa' but there is no actual QA PaaS metrics to test triggering the rules




