### PR TITLE
Refine request failures alert

### DIFF
--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -6,7 +6,11 @@ on:
       environment:
         description: Environment to deploy, qa or prod
         required: true
-        default: prod
+        type: choice
+        options:
+          - qa
+          - prod
+        default: qa
 
 jobs:
   deploy:

--- a/monitoring/config/alert.rules.tmpl
+++ b/monitoring/config/alert.rules.tmpl
@@ -67,12 +67,12 @@ groups:
   rules:
 %{ for app_name, app_config in apps ~}
   - alert: Request-Failures-${app_name}
-    expr:  sum(rate(requests{app="${app_name}", status_range=~"0xx|4xx|5xx"}[5m]))*60 > 25
+    expr: (sum(rate(requests{app="${app_name}", status_range=~"5xx"}[5m]))) / (sum(rate(requests{app="${app_name}"}[5m])) ) > 0.1
     for: 5m
     annotations:
-      summary:     Failed requests count
+      summary:     High rate of failing requests
       dashboard:   ${cfapps_dashboard_url}&var-Applications=${app_name}
-      description: "Number({{ $value }}) of non success status codes too high in the last 5 mins for ${app_name}"
+      description: "The proportion of failed 5xx HTTP requests in the past 5 min is above 10% (current value: {{ humanizePercentage $value }})"
     labels:
       severity:    high
       app:         ${app_name}

--- a/monitoring/config/alert.rules.tmpl
+++ b/monitoring/config/alert.rules.tmpl
@@ -7,10 +7,10 @@ groups:
     for: 5m
     annotations:
       summary:     ${app_name} High CPU Alert
-      dashboard:   ${grafana_dashboard_url}&var-Applications=${app_name}
+      dashboard:   ${cfapps_dashboard_url}&var-Applications=${app_name}
       description: "CPU usage has increased in the last 5 minutes (current value: {{ $value }}%)"
     labels:
-      environment: production
+      environment: ${monitoring_space_name}
       severity:    high
       app:         ${app_name}
 %{ endfor ~}
@@ -23,12 +23,12 @@ groups:
     for: 5m
     annotations:
       summary:     ${app_name} high memory utilization
-      dashboard:   ${grafana_dashboard_url}&var-Applications=${app_name}
+      dashboard:   ${cfapps_dashboard_url}&var-Applications=${app_name}
       description: "Memory utilization has increased in the last 5 minutes (current value: {{ $value }}%)"
     labels:
       severity:    high
       app:         ${app_name}
-      environment: production
+      environment: ${monitoring_space_name}
 %{ endfor ~}
 
 - name: Disk Utilisation
@@ -39,12 +39,12 @@ groups:
     for: 5m
     annotations:
       summary:     ${app_name} high disk utilization
-      dashboard:   ${grafana_dashboard_url}&var-Applications=${app_name}
+      dashboard:   ${cfapps_dashboard_url}&var-Applications=${app_name}
       description: "Disk utilization has increased in the last 5 minutes (current value: {{ $value }})%"
     labels:
       severity:    high
       app:         ${app_name}
-      environment: production
+      environment: ${monitoring_space_name}
 %{ endfor ~}
 
 - name: App Crashes
@@ -55,12 +55,12 @@ groups:
     for: 5m
     annotations:
       summary:     At least one instance of ${app_name} has crashed in the last 5 mins
-      dashboard:   ${grafana_dashboard_url}&var-Applications=${app_name}
+      dashboard:   ${cfapps_dashboard_url}&var-Applications=${app_name}
       description: At least one instance of ${app_name} has crashed in the last 5 mins
     labels:
       severity:    high
       app:         ${app_name}
-      environment: production
+      environment: ${monitoring_space_name}
 %{ endfor ~}
 
 - name: Elevated Request Failures
@@ -71,12 +71,12 @@ groups:
     for: 5m
     annotations:
       summary:     Failed requests count
-      dashboard:   ${grafana_dashboard_url}&var-Applications=${app_name}
+      dashboard:   ${cfapps_dashboard_url}&var-Applications=${app_name}
       description: "Number({{ $value }}) of non success status codes too high in the last 5 mins for ${app_name}"
     labels:
       severity:    high
       app:         ${app_name}
-      environment: production
+      environment: ${monitoring_space_name}
 %{ endfor ~}
 
 - name: Average Response Time
@@ -87,12 +87,12 @@ groups:
     for: 5m
     annotations:
       summary:     Slow running requests
-      dashboard:   ${grafana_dashboard_url}&var-Applications=${app_name}
+      dashboard:   ${cfapps_dashboard_url}&var-Applications=${app_name}
       description: "Requests in the 95 percentile taking longer than %{ if app_config.response_threshold == null }1%{ else }${app_config.response_threshold}%{ endif } seconds (current value: {{ humanize $value}}s )"
     labels:
       severity:    high
       app:         ${app_name}
-      environment: production
+      environment: ${monitoring_space_name}
 %{ endfor ~}
 
 - name: Redis Memory Utilisation
@@ -108,5 +108,5 @@ groups:
     labels:
       severity:    high
       app:         ${redis_instance}
-      environment: production
+      environment: ${monitoring_space_name}
 %{ endfor ~}

--- a/monitoring/variables.tf
+++ b/monitoring/variables.tf
@@ -31,10 +31,11 @@ locals {
   paas_api_url               = "https://api.london.cloud.service.gov.uk"
   alertmanager_slack_channel = "twd_bat_devops"
   alert_rules_variables = {
-    grafana_dashboard_url     = "https://grafana-bat.london.cloudapps.digital/d/eF19g4RZx/cf-apps?orgId=1&refresh=10s&var-SpaceName=${var.monitoring_space_name}"
-    redis_dashboard_url       = "https://grafana-bat.london.cloudapps.digital/d/_XaXFGTMz/redis?orgId=1&refresh=30s"
+    cfapps_dashboard_url     = "https://grafana-${var.monitoring_instance_name}.london.cloudapps.digital/d/eF19g4RZx/cf-apps?orgId=1&refresh=10s&var-SpaceName=${var.monitoring_space_name}"
+    redis_dashboard_url       = "https://grafana-${var.monitoring_instance_name}.london.cloudapps.digital/d/_XaXFGTMz/redis?orgId=1&refresh=30s"
     apps                      = var.alertmanager_app_config
     alertable_redis_instances = [for r in var.alertable_redis_services : split("/", r)[1]]
+    monitoring_space_name = var.monitoring_space_name
   }
   alert_rules = templatefile("./config/alert.rules.tmpl", local.alert_rules_variables)
 


### PR DESCRIPTION
### Context
The current failed requests alert fires when more than 25 requests are in the 0xx|4xx|5xx ranges which causes a lot of false positive alerts. 

https://trello.com/c/62cz6cpD

### Changes proposed in this pull request
- hardcoding of dashboard URLs and environment names replaced with variables
- reduce the status codes that trigger alerts to just the 5xx range and alerts based on the percentage of requests in that range.

### Guidance to review
- Alerts can be viewed in #twd_bat-devops_qa Slack channel