### PR TITLE
Add DNS record TTL as a configuration variable

### DIFF
--- a/dns/records/resources.tf
+++ b/dns/records/resources.tf
@@ -8,6 +8,7 @@ locals {
         zone_name           = zone_name
         resource_group_name = zone_cfg["resource_group_name"]
         target              = record_cfg["target"]
+        ttl                 = try(record_cfg["ttl"], 300)
       }
     ]
   ])
@@ -21,7 +22,7 @@ resource "azurerm_dns_cname_record" "cname_records" {
   name                = each.value.record_name
   zone_name           = each.value.zone_name
   resource_group_name = each.value.resource_group_name
-  ttl                 = 300
+  ttl                 = each.value.ttl
   record              = each.value.target
 
 }


### PR DESCRIPTION

TTL needs to be configurable per record, instead of hardcoded to 300

Changed resources.tf so TTL will now be supplied from the workspace_variables json file for each record