### PR TITLE
Add register qa cdn service domain and DNS records

### DIFF
--- a/dns/records/workspace-variables/register_qa.tfvars.json
+++ b/dns/records/workspace-variables/register_qa.tfvars.json
@@ -2,6 +2,12 @@
   "hosted_zone": {
     "register-trainee-teachers.service.gov.uk": {
       "cnames": {
+        "qa": {
+          "target": "d1r6ei57mr48qv.cloudfront.net"
+        },
+        "_a66959f8322304020cea85097566d3be.qa": {
+          "target": "_4c3ae74e94b29fe9ad84d2cd152fd0ac.xdvyhgsvzs.acm-validations.aws."
+        }
       },
     "resource_group_name": "s121p01-dns-rg"
     }

--- a/dns/records/workspace-variables/register_qa.tfvars.json
+++ b/dns/records/workspace-variables/register_qa.tfvars.json
@@ -6,7 +6,8 @@
           "target": "d1r6ei57mr48qv.cloudfront.net"
         },
         "_a66959f8322304020cea85097566d3be.qa": {
-          "target": "_4c3ae74e94b29fe9ad84d2cd152fd0ac.xdvyhgsvzs.acm-validations.aws."
+          "target": "_4c3ae74e94b29fe9ad84d2cd152fd0ac.xdvyhgsvzs.acm-validations.aws.",
+          "ttl": 86400
         }
       },
     "resource_group_name": "s121p01-dns-rg"

--- a/scripts/cloudfoundry/cdn/cdn-config.yml
+++ b/scripts/cloudfoundry/cdn/cdn-config.yml
@@ -36,6 +36,12 @@ bat-staging:
     - staging2.publish-teacher-training-courses.service.gov.uk
     - traineeteacherportal-pp.education.gov.uk
 
+register-qa:
+  service: register-cdn-qa
+  headers: *all-headers
+  domain:
+    - qa.register-trainee-teachers.service.gov.uk
+
 se-staging:
   service: schoolexperience-cdn-test
   headers: *all-headers


### PR DESCRIPTION
For the QA register service.gov.uk environment

- Add CDN register-cdn-qa

- Add qa.register-trainee-teachers.service.gov.uk and validation records