### PR TITLE
return create service command from cdn ruby script

### DIFF
--- a/scripts/cloudfoundry/cdn/cdn.rb
+++ b/scripts/cloudfoundry/cdn/cdn.rb
@@ -3,7 +3,7 @@ require 'yaml'
 require 'json'
 
 def usage(input)
-    puts "Usage: ./cdn.rb <CDN instance>"
+    puts "Usage: ./cdn.rb <create / update> <CDN instance>"
     puts "Known CDN instances:"
     puts input.keys.select{|c| !c.include? "headers"}
     exit
@@ -13,7 +13,8 @@ input = YAML.load_file('cdn-config.yml')
 
 usage(input) if ARGV.empty?
 
-_env = ARGV[0]
+_action = ARGV[0]
+_env = ARGV[1]
 
 output = {
     "headers" => input[_env]["headers"],
@@ -23,6 +24,11 @@ output = {
 
 service=input[_env]["service"]
 
-cmd = "cf update-service #{service} -c '#{output.to_json}'"
-
+if(_action == "create")
+    cmd = "cf create-service cdn-route cdn-route #{service} -c '#{output.to_json}'"
+elsif (_action == "update")
+    cmd = "cf update-service #{service} -c '#{output.to_json}'"
+else
+    usage(input)
+end
 puts cmd

--- a/scripts/cloudfoundry/cdn/readme.md
+++ b/scripts/cloudfoundry/cdn/readme.md
@@ -1,12 +1,20 @@
 ## Overview
 
-The Ruby script is to assist in generating the Cloudfoundry 'cf update-service <service_name>' command.
+The Ruby script is to assist in generating the Cloudfoundry `cf update-service <service_name>` command or `cf create-service <service> <plan> <service_name>` command
 
-As new custom domains are onboarded, there is the need to update the existing CDN service on Cloudfoundry.
+As new custom domains are onboarded, there is the need to create or update the existing CDN service on Cloudfoundry.
 
-## Example
+## Example 1
 
-An example of the 'cf update-service <service_name>' command is described below:-
+An example of the `cf create-service <service> <plane> <service_name>` command is described below:-
+
+```
+cf create-service cdn-route cdn-route bat-cdn-qa -c \
+'{"headers":["Accept","Authorization"],"domain":"qa.find-postgraduate-teacher-training.service.gov.uk,qa.register-trainee-teachers.education.gov.uk,qa.api.publish-teacher-training-courses.service.gov.uk,qa.publish-teacher-training-courses.service.gov.uk"}'
+```
+## Example 2
+
+An example of the `cf update-service <service_name>` command is described below:-
 
 ```
 cf update-service bat-cdn-qa -c \
@@ -50,13 +58,24 @@ The supplied argument (ARVG) represents the intended target environment. To run 
 |apply-prod    |Apply For Teacher Training |Production |
 
 
-Running the script with any of the above will print out the desired `cf update <service_name>` command along with the newly updated custom domain. The output can then be executed from the shell, while logged into Cloudfoundry.
+Running the script with any of the above will print out the desired `cf update-service <service_name>` or `cf create-service <service> <plan> <service_name>` command along with the newly updated custom domain. The output can then be executed from the shell, while logged into Cloudfoundry.
 
-### Example
+### Example 1 - Create
 
 ```
-./cdn.rb git-staging
+./cdn.rb create git-staging
+
+cf create-service cdn-route cdn-route get-into-teaching-cdn-test -c '{"headers":["Accept","Authorization"],"domain":"staging-adviser-getintoteaching.education.gov.uk,staging-getintoteaching.education.gov.uk"}'-staging
+
+```
+
+### Example 2 - Update
+
+```
+./cdn.rb update git-staging
 
 cf update-service get-into-teaching-cdn-test -c '{"headers":["Accept","Authorization"],"domain":"staging-adviser-getintoteaching.education.gov.uk,staging-getintoteaching.education.gov.uk"}'-staging
 
 ```
+
+


### PR DESCRIPTION
Ruby script is modified to return `cf create-service` command along with `cf update-service` command.