### PR TITLE
Added different Slack receiver for Apply alerts

### DIFF
--- a/monitoring/config/alert.rules.tmpl
+++ b/monitoring/config/alert.rules.tmpl
@@ -13,6 +13,7 @@ groups:
       environment: ${monitoring_space_name}
       severity:    high
       app:         ${app_name}
+      %{ if app_config.receiver != null }receiver:     ${app_config.receiver}%{ endif }
 %{ endfor ~}
 
 - name: Memory Utilisation
@@ -29,6 +30,7 @@ groups:
       severity:    high
       app:         ${app_name}
       environment: ${monitoring_space_name}
+      %{ if app_config.receiver != null }receiver:     ${app_config.receiver}%{ endif }
 %{ endfor ~}
 
 - name: Disk Utilisation
@@ -45,6 +47,7 @@ groups:
       severity:    high
       app:         ${app_name}
       environment: ${monitoring_space_name}
+      %{ if app_config.receiver != null }receiver:     ${app_config.receiver}%{ endif }
 %{ endfor ~}
 
 - name: App Crashes
@@ -61,6 +64,7 @@ groups:
       severity:    high
       app:         ${app_name}
       environment: ${monitoring_space_name}
+      %{ if app_config.receiver != null }receiver:     ${app_config.receiver}%{ endif }
 %{ endfor ~}
 
 - name: Elevated Request Failures
@@ -77,6 +81,7 @@ groups:
       severity:    high
       app:         ${app_name}
       environment: ${monitoring_space_name}
+      %{ if app_config.receiver != null }receiver:     ${app_config.receiver}%{ endif }
 %{ endfor ~}
 
 - name: Average Response Time
@@ -93,6 +98,7 @@ groups:
       severity:    high
       app:         ${app_name}
       environment: ${monitoring_space_name}
+      %{ if app_config.receiver != null }receiver:     ${app_config.receiver}%{ endif }
 %{ endfor ~}
 
 - name: Redis Memory Utilisation

--- a/monitoring/resources.tf
+++ b/monitoring/resources.tf
@@ -19,6 +19,7 @@ module "prometheus_all" {
   grafana_json_dashboards      = [file("dashboards/bat_runtime.json")]
 
   alert_rules            = local.alert_rules
+  alertmanager_slack_receivers = local.alertmanager_slack_receivers
   alertmanager_slack_url = local.infra_secrets["SLACK_WEBHOOK"]
 
   influxdb_service_plan = var.influxdb_service_plan

--- a/monitoring/variables.tf
+++ b/monitoring/variables.tf
@@ -9,9 +9,11 @@ variable "alertmanager_app_config" {
   type = map(
     object({
       response_threshold = optional(number)
+      receiver = optional(string)
     })
   )
 }
+variable "alertmanager_receivers" {}
 
 variable "postgres_services" {}
 variable "redis_services" {}
@@ -33,7 +35,7 @@ locals {
   azure_credentials          = try(jsondecode(var.azure_credentials), null)
   infra_secrets              = yamldecode(data.azurerm_key_vault_secret.infra_secrets.value)
   paas_api_url               = "https://api.london.cloud.service.gov.uk"
-  alertmanager_slack_channel = "twd_bat_devops"
+  alertmanager_slack_receivers = { for r in var.alertmanager_receivers : r => local.infra_secrets[r]}
   alert_rules_variables = {
     cfapps_dashboard_url     = "https://grafana-${var.monitoring_instance_name}.london.cloudapps.digital/d/eF19g4RZx/cf-apps?orgId=1&refresh=10s&var-SpaceName=${var.monitoring_space_name}"
     redis_dashboard_url       = "https://grafana-${var.monitoring_instance_name}.london.cloudapps.digital/d/_XaXFGTMz/redis?orgId=1&refresh=30s"

--- a/monitoring/workspace-variables/prod.tfvars.json
+++ b/monitoring/workspace-variables/prod.tfvars.json
@@ -23,8 +23,13 @@
     "register-production": {},
     "register-staging": {},
     "apply-staging": {},
-    "apply-prod": {}
+    "apply-prod": {
+      "receiver": "SLACK_WEBHOOK_TWD_APPLY_TECH"
+    }
   },
+  "alertmanager_receivers": [
+    "SLACK_WEBHOOK_TWD_APPLY_TECH"
+  ],
   "alertable_postgres_services": {
     "bat-prod/apply-postgres-prod": {
       "min_mem": 1

--- a/monitoring/workspace-variables/qa.tfvars.json
+++ b/monitoring/workspace-variables/qa.tfvars.json
@@ -14,8 +14,13 @@
       "response_threshold": 3
     },
     "register-qa": {},
-    "apply-qa": {}
+    "apply-qa": {
+      "receiver": "SLACK_WEBHOOK"
+    }
   },
+  "alertmanager_receivers": [
+    "SLACK_WEBHOOK"
+  ],
   "alertable_postgres_services": {
     "bat-qa/apply-postgres-qa": {
     },


### PR DESCRIPTION
### Context
Some teams would like their Prometheus alerts directed to their teams Slack channel rather than the default DevOps channel.

### Changes proposed in this pull request
- Added an optional label to alerts so that they can be routed to a different Slack receiver
- Added config to route alerts for Apply apps to a different receiver

### Guidance to review
The test alerts can be seen in #twd_bat_devops_qa Slack channel.  Alerts sent to the default channel have a "Sent to default route" footer, those sent to the additional channel don't
