### PR TITLE
Change ttapi-postgres-sandbox mem alert from 1G to 0.5G

### DIFF
--- a/monitoring/workspace-variables/prod.tfvars.json
+++ b/monitoring/workspace-variables/prod.tfvars.json
@@ -50,7 +50,6 @@
       "min_mem": 1
     },
     "bat-prod/teacher-training-api-postgres-sandbox": {
-      "min_mem": 1
     },
     "bat-staging/teacher-training-api-postgres-staging": {
     }


### PR DESCRIPTION

The ttapi sandbox postgres db memory alert threshold is currently set at 1G.
This is too high, so changing it to 0.5G.

