### PR TITLE
Set apply response threshold alert to 5

### DIFF
--- a/monitoring/workspace-variables/prod.tfvars.json
+++ b/monitoring/workspace-variables/prod.tfvars.json
@@ -24,7 +24,8 @@
     "register-staging": {},
     "apply-staging": {},
     "apply-prod": {
-      "receiver": "SLACK_WEBHOOK_TWD_APPLY_TECH"
+      "receiver": "SLACK_WEBHOOK_TWD_APPLY_TECH",
+      "response_threshold": 5
     }
   },
   "alertmanager_receivers": [


### PR DESCRIPTION
To reduce noise in the apply Slack channel the response time alert threshold limit needs to be increased to 5