### PR TITLE
Move find alerts to findpub Slack channel

### DIFF
--- a/monitoring/workspace-variables/prod.tfvars.json
+++ b/monitoring/workspace-variables/prod.tfvars.json
@@ -6,7 +6,9 @@
   "monitoring_instance_name": "bat",
   "influxdb_service_plan": "medium-1_x",
   "alertmanager_app_config": {
-    "find-prod": {},
+    "find-prod": {
+      "receiver": "SLACK_WEBHOOK_TWD_FINDPUB_TECH"
+    },
     "find-staging": {},
     "publish-teacher-training-prod": {
       "response_threshold": 5
@@ -29,7 +31,8 @@
     }
   },
   "alertmanager_receivers": [
-    "SLACK_WEBHOOK_TWD_APPLY_TECH"
+    "SLACK_WEBHOOK_TWD_APPLY_TECH",
+    "SLACK_WEBHOOK_TWD_FINDPUB_TECH"
   ],
   "alertable_postgres_services": {
     "bat-prod/apply-postgres-prod": {


### PR DESCRIPTION
To move the findpub service alerts to its own Slack channel we need to add a receiver in for alert manager. Also add the secret SLACK_WEBHOOK_TWD_FINDPUB_TECH to the relevant key vault secret.