### PR TITLE
Add receiver for register specific alerts

### DIFF
--- a/monitoring/workspace-variables/prod.tfvars.json
+++ b/monitoring/workspace-variables/prod.tfvars.json
@@ -16,7 +16,9 @@
     "publish-teacher-training-staging": {
       "response_threshold": 3
     },
-    "register-production": {},
+    "register-production": {
+      "receiver": "SLACK_WEBHOOK_TWD_REGISTER_TECH"
+    },
     "register-staging": {},
     "apply-staging": {},
     "apply-prod": {
@@ -26,7 +28,8 @@
   },
   "alertmanager_receivers": [
     "SLACK_WEBHOOK_TWD_APPLY_TECH",
-    "SLACK_WEBHOOK_TWD_FINDPUB_TECH"
+    "SLACK_WEBHOOK_TWD_FINDPUB_TECH",
+    "SLACK_WEBHOOK_TWD_REGISTER_TECH"
   ],
   "alertable_postgres_services": {
     "bat-prod/apply-postgres-prod": {
@@ -35,22 +38,17 @@
     "bat-prod/apply-postgres-sandbox": {
       "min_mem": 1
     },
-    "bat-staging/apply-postgres-staging": {
-    },
-    "bat-prod/register-postgres-production": {
-    },
-    "bat-prod/register-postgres-sandbox": {
-    },
+    "bat-staging/apply-postgres-staging": {},
+    "bat-prod/register-postgres-production": {},
+    "bat-prod/register-postgres-sandbox": {},
     "bat-staging/register-postgres-staging": {
       "min_mem": 0.25
     },
     "bat-prod/publish-teacher-training-postgres-prod": {
       "min_mem": 1
     },
-    "bat-prod/publish-teacher-training-postgres-sandbox": {
-    },
-    "bat-staging/publish-teacher-training-postgres-staging": {
-    }
+    "bat-prod/publish-teacher-training-postgres-sandbox": {},
+    "bat-staging/publish-teacher-training-postgres-staging": {}
   },
   "postgres_dashboard_url": "https://grafana-bat.london.cloudapps.digital/d/a2FR6FUMz",
   "postgres_services": [


### PR DESCRIPTION
Ensure production alerts for register go to the #twd_register_tech channel so they get the correct audience.

- [ ] Add receiver to prod.tfvars.json
- [ ] Add SLACK_WEBHOOK_TWD_REGISTER_TECH to BAT-INFRA-SECRETS-PRODUCTION key vault secret