### PR TITLE
Move reg alerts to support channel

### DIFF
--- a/monitoring/workspace-variables/prod.tfvars.json
+++ b/monitoring/workspace-variables/prod.tfvars.json
@@ -17,7 +17,7 @@
       "response_threshold": 3
     },
     "register-production": {
-      "receiver": "SLACK_WEBHOOK_TWD_REGISTER_TECH"
+      "receiver": "SLACK_WEBHOOK_TWD_REGISTER_SUPPORT"
     },
     "register-staging": {},
     "apply-staging": {},
@@ -29,7 +29,7 @@
   "alertmanager_receivers": [
     "SLACK_WEBHOOK_TWD_APPLY_TECH",
     "SLACK_WEBHOOK_TWD_FINDPUB_TECH",
-    "SLACK_WEBHOOK_TWD_REGISTER_TECH"
+    "SLACK_WEBHOOK_TWD_REGISTER_SUPPORT"
   ],
   "alertable_postgres_services": {
     "bat-prod/apply-postgres-prod": {


### PR DESCRIPTION
The register alerts should go to their dedicated support channel rather than the tech channel.