### PR TITLE
make window configurable for response time alerts

### DIFF
--- a/monitoring/config/alert.rules.tmpl
+++ b/monitoring/config/alert.rules.tmpl
@@ -89,7 +89,7 @@ groups:
 %{ for app_name, app_config in apps ~}
   - alert: Response-Times-${app_name}
     expr:  histogram_quantile(0.95, sum(rate(response_time_bucket{app="${app_name}", status_range="2xx"}[5m])) by (le)) > %{ if app_config.response_threshold == null }1%{ else }${app_config.response_threshold}%{ endif }
-    for: 5m
+    for: %{ if app_config.response_window == null }"5m"%{ else }${app_config.response_window}%{ endif }
     annotations:
       summary:     Slow running requests
       dashboard:   ${cfapps_dashboard_url}&var-Applications=${app_name}

--- a/monitoring/variables.tf
+++ b/monitoring/variables.tf
@@ -9,6 +9,7 @@ variable "alertmanager_app_config" {
   type = map(
     object({
       response_threshold = optional(number)
+      response_window    = optional(string)
       receiver = optional(string)
     })
   )

--- a/monitoring/workspace-variables/prod.tfvars.json
+++ b/monitoring/workspace-variables/prod.tfvars.json
@@ -17,9 +17,12 @@
       "response_threshold": 3
     },
     "register-production": {
-      "receiver": "SLACK_WEBHOOK_TWD_REGISTER_SUPPORT"
+      "receiver": "SLACK_WEBHOOK_TWD_REGISTER_SUPPORT",
+      "response_window": "10m"
     },
-    "register-staging": {},
+    "register-staging": {
+      "response_window": "10m"
+    },
     "apply-staging": {},
     "apply-prod": {
       "receiver": "SLACK_WEBHOOK_TWD_APPLY_TECH",

--- a/monitoring/workspace-variables/qa.tfvars.json
+++ b/monitoring/workspace-variables/qa.tfvars.json
@@ -10,7 +10,9 @@
     "publish-teacher-training-qa": {
       "response_threshold": 3
     },
-    "register-qa": {},
+    "register-qa": {
+      "response_window": "10m"
+    },
     "apply-qa": {
       "receiver": "SLACK_WEBHOOK"
     }


### PR DESCRIPTION
Allow override of window for PaaS app response time alerts

Default is 5 minutes, and this can be overridden from tfvars.json per app

This has been added for register response time alerts, which can have a temporary spike that clears within seconds,
and this should resolve those alerts from occurring

Change has been tested against QA