### PR TITLE
[670] GiT pass all headers

### DIFF
--- a/scripts/cloudfoundry/cdn/cdn-config.yml
+++ b/scripts/cloudfoundry/cdn/cdn-config.yml
@@ -68,7 +68,7 @@ se-staging:
 
 git-staging:
   service: get-into-teaching-cdn-test
-  headers: *headers
+  headers: *all-headers
   domain:
     - staging-adviser-getintoteaching.education.gov.uk
     - staging-getintoteaching.education.gov.uk
@@ -105,7 +105,7 @@ se-prod:
     - schoolexperience.education.gov.uk
 git-prod:
   service: get-into-teaching-cdn-prod
-  headers: *headers
+  headers: *all-headers
   domain:
     - adviser-getintoteaching.education.gov.uk
     - beta-adviser-getintoteaching.education.gov.uk

--- a/scripts/cloudfoundry/cdn/cdn.rb
+++ b/scripts/cloudfoundry/cdn/cdn.rb
@@ -9,7 +9,12 @@ def usage(input)
     exit
 end
 
-input = YAML.load_file('cdn-config.yml')
+begin
+    # Required for Ruby 3.1 and above
+    input = YAML.load_file('cdn-config.yml', aliases: true)
+rescue ArgumentError
+    input = YAML.load_file('cdn-config.yml')
+end
 
 usage(input) if ARGV.empty?
 


### PR DESCRIPTION
## What
- Pass all headers for GiT apps so the User-Agent header can be used in analytics
- Fix the cdn script to make it work with recent Ruby
