### PR TITLE
Lower register staging db memory alert to 100M

### DIFF
--- a/monitoring/workspace-variables/prod.tfvars.json
+++ b/monitoring/workspace-variables/prod.tfvars.json
@@ -44,7 +44,7 @@
     "bat-staging/apply-postgres-staging": {},
     "bat-prod/register-postgres-production": {},
     "bat-staging/register-postgres-staging": {
-      "min_mem": 0.25
+      "min_mem": 0.1
     },
     "bat-prod/publish-teacher-training-postgres-prod": {
       "min_mem": 1


### PR DESCRIPTION
Lower the alert threshold for the register staging postgres memory alert from 0.25 (250MB) to 0.1 (100MB)

Currently we have approx 200MB free.
If free mem drops to 100MB then we will look to increase the db memory to 2G.