### PR TITLE
Remove find2 routes as find merged with publish

### DIFF
--- a/scripts/cloudfoundry/cdn/cdn-config.yml
+++ b/scripts/cloudfoundry/cdn/cdn-config.yml
@@ -21,7 +21,6 @@ bat-qa:
     - qa.publish-teacher-training-courses.service.gov.uk
     - audit.register-trainee-teachers.education.gov.uk
     - traineeteacherportal-dv.education.gov.uk
-    - qa2.find-postgraduate-teacher-training.service.gov.uk
 bat-staging:
   service: bat-cdn-staging
   headers: *all-headers
@@ -29,7 +28,6 @@ bat-staging:
     - staging.find-postgraduate-teacher-training.service.gov.uk
     - staging.api.publish-teacher-training-courses.service.gov.uk
     - staging.publish-teacher-training-courses.service.gov.uk
-    - staging2.find-postgraduate-teacher-training.service.gov.uk
     - pen.find-postgraduate-teacher-training.service.gov.uk
     - pen.api.publish-teacher-training-courses.service.gov.uk
     - pen.publish-teacher-training-courses.service.gov.uk
@@ -77,10 +75,8 @@ bat-prod:
   headers: *all-headers
   domain:
     - www.find-postgraduate-teacher-training.service.gov.uk
-    - www2.find-postgraduate-teacher-training.service.gov.uk
     - www.register-trainee-teachers.education.gov.uk
     - sandbox.find-postgraduate-teacher-training.service.gov.uk
-    - sandbox2.find-postgraduate-teacher-training.service.gov.uk
     - sandbox.api.publish-teacher-training-courses.service.gov.uk
     - sandbox.publish-teacher-training-courses.service.gov.uk
     - www.publish-teacher-training-courses.service.gov.uk


### PR DESCRIPTION
Find has been merged with publish, so the find2 routes can now be removed from the cdn