### PR TITLE
Remove apply qa cdn as migrated to aks

### DIFF
--- a/scripts/cloudfoundry/cdn/cdn-config.yml
+++ b/scripts/cloudfoundry/cdn/cdn-config.yml
@@ -104,12 +104,6 @@ git-prod:
     - beta-adviser-getintoteaching.education.gov.uk
     - getintoteaching.education.gov.uk
     - beta-getintoteaching.education.gov.uk
-apply-qa:
-  service: apply-cdn-qa
-  headers: *apply-headers
-  domain:
-    - qa.apply-for-teacher-training.service.gov.uk
-    - qa.apply-for-teacher-training.education.gov.uk
 apply-staging:
   service: apply-cdn-staging
   headers: *apply-headers
@@ -128,7 +122,6 @@ bat-assets-qa:
   service: bat-cdn-assets-qa
   cookies: false
   domain:
-    - qa-assets.apply-for-teacher-training.service.gov.uk
     - qa-assets.find-postgraduate-teacher-training.service.gov.uk
 bat-assets-staging:
   service: bat-cdn-assets-staging


### PR DESCRIPTION
Remove apply qa cdn config as it has been migrated to AKS and frontdoor.

Requires an update to the cdn-config-yml and then
- update bat-cdn-assets-qa
- remove apply-cdn-qa