### PR TITLE
Add register pen test CDN and DNS configuration

### DIFF
--- a/dns/records/workspace-variables/backend_register_pen.tfvars
+++ b/dns/records/workspace-variables/backend_register_pen.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "s121p01-dns-rg"
+storage_account_name = "s121p01dnsterraform"
+container_name       = "register-pen-dns-tfstate"
+key                  = "dns-terraform.tfstate"

--- a/dns/records/workspace-variables/register_pen.tfvars.json
+++ b/dns/records/workspace-variables/register_pen.tfvars.json
@@ -1,0 +1,16 @@
+{
+  "hosted_zone": {
+    "register-trainee-teachers.service.gov.uk": {
+      "cnames": {
+        "pen": {
+          "target": "djxjlkprikj8.cloudfront.net"
+        },
+        "_9335bdb73caf5e52b0df1c42f1bd280d.pen": {
+          "target": "_0db6c3a97d958d49641dc36b439e6b27.dbspspvlns.acm-validations.aws.",
+          "ttl": 86400
+        }
+      },
+    "resource_group_name": "s121p01-dns-rg"
+    }
+  }
+}

--- a/scripts/cloudfoundry/cdn/cdn-config.yml
+++ b/scripts/cloudfoundry/cdn/cdn-config.yml
@@ -46,6 +46,13 @@ register-staging:
   domain:
     - staging.register-trainee-teachers.service.gov.uk
 
+register-pen:
+  service: register-cdn-pen
+  headers: *all-headers
+  domain:
+    - pen.register-trainee-teachers.service.gov.uk
+    - pen.register-trainee-teachers.education.gov.uk
+
 register-prod:
   service: register-cdn-prod
   headers: *all-headers


### PR DESCRIPTION
Add the required DNS and CDN configuration to support the Register pen test environment.

- Add a new CDN to support the pen test service and education domains
- Add the pen test domain to the DNS configuration and deploy

Outside of this PR
- Raised a request to get the education domain CNAME updates needed
- Add the container to the Azure storage account to support the tfstate file
- Application deployment configuration in https://github.com/DFE-Digital/register-trainee-teachers/pull/3172

Tested all of the above works correctly.