### PR TITLE
Remove apply sandbox as moved to aks

### DIFF
--- a/scripts/cloudfoundry/cdn/cdn-config.yml
+++ b/scripts/cloudfoundry/cdn/cdn-config.yml
@@ -113,8 +113,6 @@ apply-prod:
   domain:
     - www.apply-for-teacher-training.service.gov.uk
     - www.apply-for-teacher-training.education.gov.uk
-    - sandbox.apply-for-teacher-training.service.gov.uk
-    - sandbox.apply-for-teacher-training.education.gov.uk
 bat-assets-qa:
   service: bat-cdn-assets-qa
   cookies: false
@@ -130,7 +128,6 @@ bat-assets-prod:
   cookies: false
   domain:
     - assets.apply-for-teacher-training.service.gov.uk
-    - sandbox-assets.apply-for-teacher-training.service.gov.uk
     - assets.find-postgraduate-teacher-training.service.gov.uk
     - sandbox-assets.find-postgraduate-teacher-training.service.gov.uk
 tra-production:


### PR DESCRIPTION
Remove apply sandbox cdn config as it has been migrated to AKS and frontdoor.

Requires an update to the cdn-config-yml and then

- update bat-cdn-assets-prod
- update apply-cdn-prod