### PR TITLE
Allow local userpass authentication

### DIFF
--- a/sqlpad/variables.tf
+++ b/sqlpad/variables.tf
@@ -29,7 +29,7 @@ locals {
     SQLPAD_ADMIN                  = local.infra_secrets["SQLPAD_ADMIN_ID"]
     SQLPAD_BACKEND_DB_URI         = "${cloudfoundry_service_key.postgres_service_key.credentials.uri}?ssl=no-verify"
     SQLPAD_QUERY_RESULT_MAX_ROWS  = 100000
-    SQLPAD_USERPASS_AUTH_DISABLED = true
+    SQLPAD_USERPASS_AUTH_DISABLED = false
     PUBLIC_URL                    = "https://${cloudfoundry_route.web_app_cloudapps_digital_route.endpoint}"
     SQLPAD_GOOGLE_CLIENT_ID       = local.infra_secrets["SQLPAD_GOOGLE_CLIENT_ID"]
     SQLPAD_GOOGLE_CLIENT_SECRET   = local.infra_secrets["SQLPAD_GOOGLE_CLIENT_SECRET"]

--- a/sqlpad/workspace_variables/prod.tfvars.json
+++ b/sqlpad/workspace_variables/prod.tfvars.json
@@ -4,5 +4,6 @@
   "key_vault_resource_group": "s121p01-shared-rg",
   "paas_space_name": "bat-prod",
   "app_name": "sqlpad-bat",
-  "postgres_name": "register-sqlpad-postgres"
+  "postgres_name": "register-sqlpad-postgres",
+  "app_memory": 2048
 }


### PR DESCRIPTION
Allow sqlpad to use local user/pass authentication due to the google workspace migration

for sqlpad-bat
make prod deploy[-plan]

for sqlpad-bat-qa
set env var and restage

Also increased webapp memory for sqlpad-bat to 2G as this was changed previously on the app (but not in the code)

