### PR TITLE
Remove register prod from cdn as moved to aks

### DIFF
--- a/scripts/cloudfoundry/cdn/cdn-config.yml
+++ b/scripts/cloudfoundry/cdn/cdn-config.yml
@@ -25,12 +25,6 @@ bat-staging:
     - pen.publish-teacher-training-courses.service.gov.uk
     - traineeteacherportal-pp.education.gov.uk
 
-register-prod:
-  service: register-cdn-prod
-  headers: *all-headers
-  domain:
-    - www.register-trainee-teachers.service.gov.uk
-
 se-staging:
   service: schoolexperience-cdn-test
   headers: *all-headers
@@ -54,7 +48,6 @@ bat-prod:
   headers: *all-headers
   domain:
     - www.find-postgraduate-teacher-training.service.gov.uk
-    - www.register-trainee-teachers.education.gov.uk
     - sandbox.find-postgraduate-teacher-training.service.gov.uk
     - sandbox.api.publish-teacher-training-courses.service.gov.uk
     - sandbox.publish-teacher-training-courses.service.gov.uk


### PR DESCRIPTION
Remove register prod cdn config as it has been migrated to AKS and frontdoor.

Requires an update to the cdn-config-yml and then

update bat-cdn-prod
remove register-cdn-prod