### PR TITLE
Enable azure rbac deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ read-cluster-config:
 
 get-cluster-credentials: read-cluster-config set-azure-account ## make <config> get-cluster-credentials [ENVIRONMENT=<clusterX>]
 	az aks get-credentials --overwrite-existing -g ${AZURE_RESOURCE_PREFIX}-tsc-${CLUSTER_SHORT}-rg -n ${AZURE_RESOURCE_PREFIX}-tsc-${CLUSTER}-aks
+	kubelogin convert-kubeconfig -l $(if ${GITHUB_ACTIONS},spn,azurecli)
 
 ssh: get-cluster-credentials
 	$(if $(APP_NAME), $(eval export APP_ID=$(APP_NAME)) , $(eval export APP_ID=$(CONFIG)))

--- a/sqlpad-aks/terraform.tf
+++ b/sqlpad-aks/terraform.tf
@@ -30,4 +30,13 @@ provider "kubernetes" {
   client_certificate     = module.cluster_data.kubernetes_client_certificate
   client_key             = module.cluster_data.kubernetes_client_key
   cluster_ca_certificate = module.cluster_data.kubernetes_cluster_ca_certificate
+
+  dynamic "exec" {
+    for_each = module.cluster_data.azure_RBAC_enabled ? [1] : []
+    content {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "kubelogin"
+      args        = module.cluster_data.kubelogin_args
+    }
+  }
 }


### PR DESCRIPTION
## Description

Enable azure rbac on deployment (for when it is enabled in the cluster)

## Trello Card Link

https://trello.com/c/3m8PNLG6/937-enable-azure-rbac-deployment-on-all-services

### Changes proposed in this pull request

Update Makefile and terraform to use rbac if configured for the cluster

### Guidance to review

make qa_aks get-cluster-credentials
make qa_aks sqlpad-plan-aks
make production_aks get-cluster-credentials CONFIRM_PRODUCTION=y
make production_aks sqlpad-plan-aks CONFIRM_PRODUCTION=y
